### PR TITLE
README.md: add mxml as required dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Thumb depends upon a number of external libraries. Binary distributions of Thumb
 - [zlib](http://www.zlib.net) decompresses data.
 - [ODE](http://ode.org) performs physics simulation.
 - [zip](http://www.info-zip.org/Zip.html) helps embed static data.
+- [mxml](http://www.minixml.org/) small XML parsing library
 
 Optionally,
 


### PR DESCRIPTION
add mxml to dependency list with link. This package is available as libmxml-dev in Ubuntu repositories.
